### PR TITLE
Migrate from `name.full()` to `name_full()` to future-proof editing a user into an organization

### DIFF
--- a/docassemble/DebtCollectorLetter/data/questions/debt_collector_letter.yml
+++ b/docassemble/DebtCollectorLetter/data/questions/debt_collector_letter.yml
@@ -1386,7 +1386,7 @@ review:
   - Edit: user.name.first
     button: |
       **What is your name?**
-      ${ user.name.full(middle="full") }
+      ${ user.name_full() }
   - Edit: user.address.address
     button: |
       **What is your address?**
@@ -1610,7 +1610,7 @@ review:
   - Edit: user.name.first
     button: |
       **What is your name?**
-      ${ user.name.full(middle="full") }
+      ${ user.name_full() }
   - Edit: user.address.address
     button: |
       **What is your address?**


### PR DESCRIPTION

Previously, it was possible to have leftover text in the .name.last field which would not be removed
if the user used a review screen and changed the person type from Individual to Business.

This PR replaces any use of `.name.full(middle="full")` with `name_full()`, which in a future
version of the AssemblyLine framework will solve this problem by not printing the last name
when the `person_type` is "business"

## How this change was made

This change was made by searching for any repos that had the text `name.full(middle="full") using gh-search,
and then the text was replaced with turbolift --sed as follows:

```bash
turbolift foreach -- bash -lc '
  # 1) enable ** to recurse
  shopt -s globstar

  # 2) for each .yml, replace both " and '\'' variants
  for f in **/*.yml; do
    sed -i "s/name\.full(middle=\"full\")/name_full()/g" "$f"
    sed -i "s/name\.full(middle='\''full'\'')/name_full()/g" "$f"
  done
'
```

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>